### PR TITLE
Add type attribute, mobile IE11 stabilisation

### DIFF
--- a/src/js/helpers/formats.js
+++ b/src/js/helpers/formats.js
@@ -1,0 +1,17 @@
+const formats = {
+	mpeg4: [
+		'video/mp4; codecs="mp4v.20.8"'
+	],
+	h264: [
+		'video/mp4; codecs="avc1.42E01E"',
+		'video/mp4; codecs="avc1.42E01E, mp4a.40.2"'
+	],
+	ogg: [
+		'video/ogg; codecs="theora"'
+	],
+	webm: [
+		'video/webm; codecs="vp8, vorbis"'
+	]
+};
+
+export default formats;

--- a/src/js/helpers/supported-formats.js
+++ b/src/js/helpers/supported-formats.js
@@ -1,20 +1,5 @@
+import formats from './formats';
 const testEl = document.createElement('video');
-
-const formats = {
-	mpeg4: [
-		'video/mp4; codecs="mp4v.20.8"'
-	],
-	h264: [
-		'video/mp4; codecs="avc1.42E01E"',
-		'video/mp4; codecs="avc1.42E01E, mp4a.40.2"'
-	],
-	ogg: [
-		'video/ogg; codecs="theora"'
-	],
-	webm: [
-		'video/webm; codecs="vp8, vorbis"'
-	]
-};
 
 let supportedFormats = [];
 if (testEl.canPlayType) {

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -1,6 +1,7 @@
 /* global fetch */
 import crossDomainFetch from 'o-fetch-jsonp';
 import getRendition from './helpers/get-rendition';
+import formats from './helpers/formats';
 import VideoAds from './ads';
 
 function eventListener(video, ev) {
@@ -33,6 +34,13 @@ function updatePosterUrl(posterImage, width) {
 	}
 	return url;
 };
+
+function getVideoType(videoCodec) {
+	const videoTypes = (typeof videoCodec === 'string') ? formats[videoCodec.toLowerCase()] : null;
+	if (videoTypes && typeof videoTypes[0] === 'string') {
+		return videoTypes[0].split(';')[0];
+	}
+}
 
 // converts data-o-video attributes to an options object
 function getOptionsFromDataAttributes(attributes) {
@@ -149,6 +157,9 @@ class Video {
 		this.videoEl.setAttribute('controls', true);
 		this.videoEl.setAttribute('poster', this.posterImage);
 		this.videoEl.setAttribute('src', this.rendition && this.rendition.url);
+		if (this.rendition && getVideoType(this.rendition.videoCodec)) {
+			this.videoEl.setAttribute('type', getVideoType(this.rendition.videoCodec));
+		}
 		this.videoEl.className = Array.isArray(this.opts.classes) ? this.opts.classes.join(' ') : this.opts.classes;
 		this.containerEl.classList.add('o-video--player');
 		this.containerEl.appendChild(this.videoEl);

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -81,7 +81,8 @@ describe('Video', () => {
 		it('should add a video element', () => {
 			const video = new Video(containerEl);
 			video.rendition = {
-				url: 'http://url.mock'
+				url: 'http://url.mock',
+				videoCodec: 'H264'
 			};
 			video.posterImage = 'mockimage';
 			video.addVideo();
@@ -90,6 +91,7 @@ describe('Video', () => {
 			video.videoEl.parentElement.should.equal(containerEl);
 			video.videoEl.getAttribute('poster').should.equal('mockimage');
 			video.videoEl.getAttribute('src').should.equal('http://url.mock');
+			video.videoEl.getAttribute('type').should.equal('video/mp4');
 			video.videoEl.getAttribute('controls').should.equal('true');
 		});
 


### PR DESCRIPTION
https://jira.ft.com/browse/NFT-550 reports video failing on mobile windows IE11 and edge, I have found to work but be flaky.

Grey box is present for a long time (probably speed issue) and a decode error will sometimes be thrown.

This adds 'type' to the video element in the _hope_ that it gives enough assistance to the user agent to improve stability.
