### PR TITLE
Fix and improve video width selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Where `opts` is an optional object with properties
 
  * `id` [`Number`] Source's ID of the video
  * `source` [`String`] Source of the video (currently only accepts `brightcove`)
- * `optimumwidth` [`Number`] The optimum width of the video, used when there are multiple video renditions available to
+ * `optimumwidth` [`Number`] The optimum width of the video placeholder image
+ * `optimumvideowidth` [`Number`] The optimum width of the video itself, used when there are multiple video renditions available to
  decide which to display (the smallest one that's at least as large as this width, if it exists)
  * `placeholder` [`Boolean`] Show just the poster image, load (and play) video on click
  * `placeholdertitle` [`Boolean`] Show just the title as an overlay on the placeholder

--- a/src/js/helpers/get-rendition.js
+++ b/src/js/helpers/get-rendition.js
@@ -3,7 +3,7 @@ import supportedFormats from './supported-formats';
 function getRendition(renditions, options) {
 	// allow mocking of supported formats module
 	const opts = options || {};
-	const width = opts.optimumwidth;
+	const width = opts.optimumvideowidth;
 	const formats = opts.supportedFormats || supportedFormats();
 	let appropriateRendition;
 	// order smallest to largest
@@ -28,7 +28,7 @@ function getRendition(renditions, options) {
 		return false;
 	});
 
-	return appropriateRendition || orderedRenditions.shift();
+	return appropriateRendition || orderedRenditions.pop();
 };
 
 export default getRendition;

--- a/src/js/helpers/get-rendition.js
+++ b/src/js/helpers/get-rendition.js
@@ -3,7 +3,7 @@ import supportedFormats from './supported-formats';
 function getRendition(renditions, options) {
 	// allow mocking of supported formats module
 	const opts = options || {};
-	const width = opts.width;
+	const width = opts.optimumwidth;
 	const formats = opts.supportedFormats || supportedFormats();
 	let appropriateRendition;
 	// order smallest to largest

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -117,7 +117,7 @@ class Video {
 		return dataPromise.then(data => {
 			this.videoData = data;
 			this.posterImage = updatePosterUrl(data.videoStillURL, this.opts.optimumwidth);
-			this.rendition = getRendition(data.renditions);
+			this.rendition = getRendition(data.renditions, this.opts);
 		});
 	}
 

--- a/test/helpers/get-rendition.test.js
+++ b/test/helpers/get-rendition.test.js
@@ -16,12 +16,12 @@ describe('Get Appropriate Renditions', () => {
 	});
 
 	it('should get rendition of at least the width supplied', () => {
-		getRendition(renditions, { supportedFormats: supportedFormats, width: 410 })
+		getRendition(renditions, { supportedFormats: supportedFormats, optimumwidth: 410 })
 			.should.have.property('id', 4085577902001);
 	});
 
 	it('should get smallest rendition if width is small', () => {
-		getRendition(renditions, { supportedFormats: supportedFormats, width: 390 })
+		getRendition(renditions, { supportedFormats: supportedFormats, optimumwidth: 390 })
 			.should.have.property('id', 4085577899001);
 	});
 

--- a/test/helpers/get-rendition.test.js
+++ b/test/helpers/get-rendition.test.js
@@ -16,13 +16,19 @@ describe('Get Appropriate Renditions', () => {
 	});
 
 	it('should get rendition of at least the width supplied', () => {
-		getRendition(renditions, { supportedFormats: supportedFormats, optimumwidth: 410 })
+		getRendition(renditions, { supportedFormats: supportedFormats, optimumvideowidth: 410 })
 			.should.have.property('id', 4085577902001);
 	});
 
 	it('should get smallest rendition if width is small', () => {
-		getRendition(renditions, { supportedFormats: supportedFormats, optimumwidth: 390 })
+		getRendition(renditions, { supportedFormats: supportedFormats, optimumvideowidth: 390 })
 			.should.have.property('id', 4085577899001);
+	});
+
+
+	it('should get largest rendition if width is bigger than any renditions', () => {
+		getRendition(renditions, { supportedFormats: supportedFormats, optimumvideowidth: 2048 })
+			.should.have.property('id', 4085577922001);
 	});
 
 });

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -363,8 +363,8 @@ describe('Video', () => {
 					);
 				});
 		});
-		it('should request an optimised rendition if optimumwidth defined', () => {
-			containerEl.setAttribute('data-o-video-optimumwidth', '300');
+		it('should request an optimised rendition if optimumvideowidth defined', () => {
+			containerEl.setAttribute('data-o-video-optimumvideowidth', '300');
 			const video = new Video(containerEl);
 			return video.getData()
 				.then(() => {

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -1,4 +1,4 @@
-/* global describe, context, it, beforeEach, afterEach, before, after, should */
+/* global describe, context, it, beforeEach, afterEach, should */
 const Video = require('./../src/js/video');
 const brightcoveResponse1 = require('./fixtures/brightcove-1.json');
 const brightcoveResponse2 = require('./fixtures/brightcove-2.json');

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -336,7 +336,7 @@ describe('Video', () => {
 
 		let fetchStub;
 
-		before(() => {
+		beforeEach(() => {
 			fetchStub = sinon.stub(window, 'fetch');
 			const res = new window.Response(JSON.stringify(brightcoveResponse1), {
 				status: 200,
@@ -347,7 +347,7 @@ describe('Video', () => {
 			fetchStub.returns(Promise.resolve(res));
 		});
 
-		after(() => {
+		afterEach(() => {
 			fetchStub.restore();
 		});
 
@@ -361,6 +361,14 @@ describe('Video', () => {
 						'https%3A%2F%2Fbcsecure01-a.akamaihd.net%2F13%2F47628783001%2F201502%2F2470%2F47628783001_4085962850001_MAS-VIDEO-AuthersNote-stock-market.jpg%3FpubId%3D47628783001' +
 						'?source=o-video&fit=scale-down&width=300'
 					);
+				});
+		});
+		it('should request an optimised rendition if optimumwidth defined', () => {
+			containerEl.setAttribute('data-o-video-optimumwidth', '300');
+			const video = new Video(containerEl);
+			return video.getData()
+				.then(() => {
+					video.rendition.frameWidth.should.equal(400);
 				});
 		});
 


### PR DESCRIPTION
There's currently code in `get-rendition` to select which size of video to use, which was documented as being controlled by the `optimumwidth` video parameter.  However... the rendition code didn't use any supplied width, possibly due to [this change in n-video](https://github.com/Financial-Times/n-video/pull/36).  As a result the live behaviour is that the documentation is wrong and the supplied `optimumwidth` parameter is only used for the placeholder image.

Rather than breaking the functionality for anyone currently depending on the size behaviour, I've added a new option for `optimumvideowidth` to allow rendition selection.

The rendition selection code was also a bit broken; it sorted the sizes, then chose the size which was closest in width to the size supplied, as long as it had a larger video to select.  If there were no videos larger than the optimum size selected, it instead chose the _smallest_ video; I've changed this to select the largest.
