### PR TITLE
send playing event to spoor

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -153,7 +153,7 @@ class Video {
 
 		this.containerEl.appendChild(this.videoEl);
 
-		addEvents(this, ['play', 'pause', 'ended']);
+		addEvents(this, ['play', 'playing', 'pause', 'ended']);
 		this.videoEl.addEventListener('playing', this.pauseOtherVideos);
 		this.videoEl.addEventListener('suspend', this.clearCurrentlyPlaying);
 		this.videoEl.addEventListener('ended', this.clearCurrentlyPlaying);

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -111,12 +111,13 @@ describe('Video', () => {
 			Element.prototype.addEventListener = addEventListenerSpy;
 
 			video.addVideo();
-			addEventListenerSpy.callCount.should.equal(6);
+			addEventListenerSpy.callCount.should.equal(7);
 			addEventListenerSpy.alwaysCalledOn(video.videoEl).should.equal(true);
 			addEventListenerSpy.calledWith('playing', video.pauseOtherVideos);
 			addEventListenerSpy.calledWith('suspend', video.clearCurrentlyPlaying);
 			addEventListenerSpy.calledWith('ended', video.clearCurrentlyPlaying);
 			addEventListenerSpy.calledWith('play');
+			addEventListenerSpy.calledWith('playing');
 			addEventListenerSpy.calledWith('pause');
 			addEventListenerSpy.calledWith('ended');
 


### PR DESCRIPTION
cc @JakeChampion @commuterjoy 

Sends spoor event for `playing`. May eventually replace `play`, which is really a 'resume', but leaving both in for now.
