### PR TITLE
Faster poster images

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -26,7 +26,7 @@ function addEvents(video, events) {
 
 // use the image resizing service, if width supplied
 function updatePosterUrl(posterImage, width) {
-	let url = `https://image.webservices.ft.com/v1/images/raw/${encodeURIComponent(posterImage)}?source=o-video`;
+	let url = `https://image.webservices.ft.com/v1/images/raw/${encodeURIComponent(posterImage)}?source=o-video&quality=low`;
 	if (width) {
 		url += `&fit=scale-down&width=${width}`;
 	}

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -377,7 +377,7 @@ describe('Video', () => {
 					video.posterImage.should.equal(
 						'https://image.webservices.ft.com/v1/images/raw/' +
 						'https%3A%2F%2Fbcsecure01-a.akamaihd.net%2F13%2F47628783001%2F201502%2F2470%2F47628783001_4085962850001_MAS-VIDEO-AuthersNote-stock-market.jpg%3FpubId%3D47628783001' +
-						'?source=o-video&fit=scale-down&width=300'
+						'?source=o-video&quality=low&fit=scale-down&width=300'
 					);
 				});
 		});


### PR DESCRIPTION
I suggest using low quality setting for poster images. 
- On next the poster is covered by an overlay and play button, so it's less visible than other images
- The webapp embeds o-video and wants the video to start ASAP, so the poster shouldn't compete for bandwidth with the video file.
