### PR TITLE
Update play icon

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "main.scss"
   ],
   "dependencies": {
-    "o-icons": "^4.0.0",
+    "o-icons": "^4.4.2",
     "o-colors": "^3.3.0",
     "o-fetch-jsonp": "^2.0.0"
   }

--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -47,7 +47,7 @@
 	}
 
 	.o-video__play-button-icon {
-		@include oIconsGetIcon('play', oColorsGetPaletteColor('white'), 40);
+		@include oIconsGetIcon('play', oColorsGetPaletteColor('white'), 60, $iconset-version: 1);
 		@include oIconsBaseStyles;
 		position: absolute;
 		top: 0;


### PR DESCRIPTION
Use the play icon from the new icon set.
This commit:
- bumps the o-icons version
- increases the icon size

Before:

![screen shot 2016-09-14 at 14 28 33](https://cloud.githubusercontent.com/assets/68009/18513991/9e866d7e-7a87-11e6-8682-1743314d199b.png)

After:

![screen shot 2016-09-14 at 14 28 56](https://cloud.githubusercontent.com/assets/68009/18513999/a46fcca8-7a87-11e6-831e-cc9ddfa3a723.png)
