### PR TITLE
allProgress flag, remove duplicate play event, add seeked event

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Where `opts` is an optional object with properties
  * `placeholderInfo` [`Array`] A list of extra information to display on the placeholder (Available: title, description, brand)
  * `playsinline` [`Boolean`] Whether to play the [video inline](https://webkit.org/blog/6784/new-video-policies-for-ios/) on iOS smallscreen (defaults to fullscreen)
  * `classes` [`Array`] Classes to add to the video (and placeholder) element
+ * `advertising` [`Boolean`] whether or not to show ads on the video
+ * `allProgress` [`Boolean`] set to true to send all native video progress events to spoor (defaults to sending at 25%/50%/75%)
 
 The config options can also be set as data attribute to instantiate the module declaratively:
 

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -9,7 +9,7 @@ function eventListener(video, ev) {
 
 	// Dispatch progress event at start, 25%, 50%, 75% and 100%
 	// If allProgress is set to true, then we send spoor events for every native video progress event (every 5 sec)
-	if (!video.allProgress && ev.type === 'progress' && video.getProgress() % 25 !== 0) {
+	if (!video.opts.allProgress && ev.type === 'progress' && video.getProgress() % 25 !== 0) {
 		return;
 	}
 
@@ -68,6 +68,7 @@ function getOptionsFromDataAttributes(attributes) {
 
 const defaultOpts = {
 	advertising: false,
+	allProgress: false,
 	autorender: true,
 	classes: [],
 	optimumwidth: null,

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -6,8 +6,10 @@ import VideoInfo from './info';
 import Playlist from './playlist';
 
 function eventListener(video, ev) {
+
 	// Dispatch progress event at start, 25%, 50%, 75% and 100%
-	if (ev.type === 'progress' && video.getProgress() % 25 !== 0) {
+	// If allProgress is set to true, then we send spoor events for every native video progress event (every 5 sec)
+	if (!video.allProgress && ev.type === 'progress' && video.getProgress() % 25 !== 0) {
 		return;
 	}
 
@@ -166,7 +168,7 @@ class Video {
 
 		this.containerEl.appendChild(this.videoEl);
 
-		addEvents(this, ['play', 'playing', 'pause', 'ended', 'progress']);
+		addEvents(this, ['playing', 'pause', 'ended', 'progress', 'seeked']);
 		this.videoEl.addEventListener('playing', this.pauseOtherVideos.bind(this));
 		this.videoEl.addEventListener('suspend', this.clearCurrentlyPlaying.bind(this));
 		this.videoEl.addEventListener('ended', this.clearCurrentlyPlaying.bind(this));

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -42,6 +42,7 @@ describe('Video', () => {
 			const video = new Video(containerEl);
 
 			video.opts.advertising.should.eql(false);
+			video.opts.allProgress.should.eql(false);
 			video.opts.classes.should.be.an.instanceOf(Array);
 			video.opts.classes.should.contain('o-video__video');
 			should.equal(video.opts.optimumwidth, null);


### PR DESCRIPTION
@JakeChampion 
- added the `seeked` event, requested by product/analytics
- removed the `play` event since `playing` gives us everything we need
- added a `videoPlayerAllProgress` flag to pass `allProgress` into `o-video` so that we send the progress event to spoor every time, not just at 25, 50, 75. See https://github.com/Financial-Times/next-stream-page/pull/1409
