### PR TITLE
Progress

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -6,7 +6,7 @@
 	"supportStatus": "active",
 	"support": "github.com/Financial-Times/o-video/issues",
 	"browserFeatures": {
-		"required": ["fetch", "Array.prototype.find", "Object.assign"]
+		"required": ["fetch", "Array.prototype.find", "Array.prototype.includes", "Object.assign"]
 	},
 	"demosDefaults": {
 		"sass": "demos/src/main.scss",

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -28,7 +28,7 @@ function eventListener(video, ev) {
 
 function shouldDispatch(progress) {
 
-	const relevantProgressPoints = [ 8,  9, 10, 11, 12,
+	const relevantProgressPoints = [8, 9, 10, 11, 12,
 									23, 24, 25, 26, 27,
 									48, 49, 50, 51, 52,
 									73, 74, 75, 76, 77,

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -7,9 +7,9 @@ import Playlist from './playlist';
 
 function eventListener(video, ev) {
 
-	// Dispatch progress event at start, 25%, 50%, 75% and 100%
+	// Dispatch progress event at around 25%, 50%, 75% and 100%
 	// If allProgress is set to true, then we send spoor events for every native video progress event (every 5 sec)
-	if (!video.opts.allProgress && ev.type === 'progress' && video.getProgress() % 25 !== 0) {
+	if (!video.opts.allProgress && ev.type === 'progress' && !shouldDispatch(video.getProgress())) {
 		return;
 	}
 
@@ -24,6 +24,15 @@ function eventListener(video, ev) {
 		bubbles: true
 	});
 	document.body.dispatchEvent(event);
+}
+
+function shouldDispatch(progress) {
+
+	const relevantProgressPoints = [22, 23, 24, 25, 26, 27, 28,
+									47, 48, 49, 50, 51, 52, 53,
+									72, 73, 74, 75, 76, 77, 78];
+
+	return relevantProgressPoints.includes(progress);
 }
 
 function addEvents(video, events) {

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -28,9 +28,11 @@ function eventListener(video, ev) {
 
 function shouldDispatch(progress) {
 
-	const relevantProgressPoints = [22, 23, 24, 25, 26, 27, 28,
-									47, 48, 49, 50, 51, 52, 53,
-									72, 73, 74, 75, 76, 77, 78];
+	const relevantProgressPoints = [ 8,  9, 10, 11, 12,
+									23, 24, 25, 26, 27,
+									48, 49, 50, 51, 52,
+									73, 74, 75, 76, 77,
+									100];
 
 	return relevantProgressPoints.includes(progress);
 }


### PR DESCRIPTION
- Not all videos hit exactly 25% 50% and 75%. Emit events for nearby values too.
- The progress==0 event can get emitted multiple times for the same video, distorting results, so it was removed.

(@JakeChampion there are less verbose ways to implement this, but I found this one to be the easiest to read/maintain)
