### PR TITLE
removes code referencing old test flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Where `opts` is an optional object with properties
  * `playsinline` [`Boolean`] Whether to play the [video inline](https://webkit.org/blog/6784/new-video-policies-for-ios/) on iOS smallscreen (defaults to fullscreen)
  * `classes` [`Array`] Classes to add to the video (and placeholder) element
  * `advertising` [`Boolean`] whether or not to show ads on the video
- * `allProgress` [`Boolean`] set to true to send all native video progress events to spoor (defaults to sending at 25%/50%/75%)
 
 The config options can also be set as data attribute to instantiate the module declaratively:
 

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -18,8 +18,7 @@ function eventListener(video, ev) {
 	}
 
 	// Dispatch progress event at around 25%, 50%, 75% and 100%
-	// If allProgress is set to true, then we send spoor events for every native video progress event (every 5 sec)
-	if (!video.opts.allProgress && ev.type === 'progress' && !shouldDispatch(video.getProgress())) {
+	if (ev.type === 'progress' && !shouldDispatch(video.getProgress())) {
 		return;
 	}
 

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -42,7 +42,6 @@ describe('Video', () => {
 			const video = new Video(containerEl);
 
 			video.opts.advertising.should.eql(false);
-			video.opts.allProgress.should.eql(false);
 			video.opts.classes.should.be.an.instanceOf(Array);
 			video.opts.classes.should.contain('o-video__video');
 			should.equal(video.opts.optimumwidth, null);


### PR DESCRIPTION
Not urgent, but the flag no longer exists (it was used for testing a while back) so I've removed the code that referenced it
cc @JakeChampion 