### PR TITLE
Video duration is an integer

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -30,7 +30,7 @@ function eventListener(video, ev) {
 			category: 'video',
 			contentId: video.opts.id,
 			progress: video.getProgress(),
-			duration: video.videoEl.duration
+			duration: video.getDuration()
 		},
 		bubbles: true
 	});
@@ -287,6 +287,10 @@ class Video {
 
 	getProgress() {
 		return this.videoEl.duration ? parseInt(100 * this.videoEl.currentTime / this.videoEl.duration, 10) : 0;
+	}
+
+	getDuration() {
+		return this.videoEl.duration ? parseInt(this.videoEl.duration, 10) : 0;
 	}
 
 	pauseOtherVideos() {

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -373,6 +373,29 @@ describe('Video', () => {
 
 	});
 
+	describe('#getDuration', () => {
+		let video;
+
+		beforeEach(() => {
+			video = new Video(containerEl);
+			video.videoEl = {};
+		});
+
+		afterEach(() => {
+			video = undefined;
+		});
+
+		it('should return 0 if duration is not set', () => {
+			video.getDuration().should.equal(0);
+		});
+
+		it('should return the duration of the video as a integer', () => {
+			video.videoEl.duration = 22.46324646;
+			video.getDuration().should.equal(22);
+		});
+
+	});
+
 	describe('#getData', () => {
 
 		let fetchStub;


### PR DESCRIPTION
By default the duration is reported as `ss.mm`, often to ~12 decimal places, which makes grouping at reporting stage less useful.