### PR TITLE
Ensure adRequested event bubbles

### DIFF
--- a/src/js/ads.js
+++ b/src/js/ads.js
@@ -130,11 +130,12 @@ class VideoAds {
 
 		// Temporary fix to verify DFP behaviour
 		const options = {
-			category: 'video',
-			action: 'adRequested',
 			detail: {
+				category: 'video',
+				action: 'adRequested',
 				contentId: this.video.opts.id
-			}
+			},
+			bubbles: true
 		};
 		const requestedEvent = new CustomEvent('oTracking.event', options);
 		document.body.dispatchEvent(requestedEvent);


### PR DESCRIPTION
so, yeah, it doesn't bubble by default