### PR TITLE
Handle getting the ad error correctly

### DIFF
--- a/src/js/ads.js
+++ b/src/js/ads.js
@@ -326,9 +326,11 @@ class VideoAds {
 	}
 
 	adErrorHandler(adError) {
+		// NOTE: has the API changed? now need to call `getError` method to get the ad error
+		const actualError = ('getError' in adError) ? adError.getError() : adError;
 
 		// convert the Google Ad error to a JS one
-		const message = `${adError.getErrorCode()}, ${adError.getType()}, ${adError.getMessage()}, ${adError.getVastErrorCode()}`;
+		const message = `${actualError.getErrorCode()}, ${actualError.getType()}, ${actualError.getMessage()}, ${actualError.getVastErrorCode()}`;
 		this.reportError(new Error(message));
 
 		this.adsManager && this.adsManager.destroy();

--- a/src/js/ads.js
+++ b/src/js/ads.js
@@ -327,7 +327,7 @@ class VideoAds {
 
 	adErrorHandler(adError) {
 		// NOTE: has the API changed? now need to call `getError` method to get the ad error
-		const actualError = ('getError' in adError) ? adError.getError() : adError;
+		const actualError = ('getError' in adError && typeof adError.getError === 'function') ? adError.getError() : adError;
 
 		// convert the Google Ad error to a JS one
 		const message = `${actualError.getErrorCode()}, ${actualError.getType()}, ${actualError.getMessage()}, ${actualError.getVastErrorCode()}`;


### PR DESCRIPTION
Not sure if this is an update to the API, or the type of error that's being passed, but now we need to call `getError` to get the actual ad error