### PR TITLE
Play button text

### DIFF
--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -44,6 +44,7 @@
 		height: 1px;
 		margin: -1px;
 		overflow: hidden;
+		color: oColorsGetPaletteColor('white');
 	}
 
 	.o-video__play-button-icon {


### PR DESCRIPTION
Default black test on the claret background of the placeholder trips a11y tests, even when the text is hidden

cc @keirog 
![screen shot 2017-02-16 at 11 35 35](https://cloud.githubusercontent.com/assets/3425322/23019831/24129a98-f43c-11e6-8fdd-0469e2752c63.png)
