### PR TITLE
Deal with quotes in data more robustly

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -84,8 +84,7 @@ function getOptionsFromDataAttributes(attributes) {
 
 			try {
 				// If it's a JSON, a boolean or a number, we want it stored like that, and not as a string
-				// We also replace all ' with " so JSON strings are parsed correctly
-				opts[key] = JSON.parse(attr.value.replace(/\'/g, '"'));
+				opts[key] = JSON.parse(attr.value);
 			} catch (e) {
 				opts[key] = attr.value;
 			}

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -764,5 +764,40 @@ describe('Video', () => {
 					video.videoData.renditions.length.should.equal(0);
 				});
 		});
+
+		context('dealing with quotes', () => {
+			const quoteyData = {
+				title: 'Macron - What next?',
+				standfirst: 'President-elect\'s "pro-EU" and trade agenda',
+				description: "Another 'great' \"quote here\"",
+				renditions: []
+			};
+
+			const videoDataShouldMatch = video => {
+				video.videoData.title.should.equal('Macron - What next?');
+				video.videoData.standfirst.should.equal('President-elect\'s "pro-EU" and trade agenda');
+				video.videoData.description.should.equal('Another \'great\' "quote here"');
+				video.videoData.renditions.length.should.equal(0);
+			};
+
+			it('can deal with quotes when data passed via constructor', () => {
+				const video = new Video(containerEl, {
+					data: quoteyData
+				});
+
+				return video
+					.getData()
+					.then(() => videoDataShouldMatch(video));
+			});
+
+			it('can deal with quotes when data passed via attribute', () => {
+				containerEl.setAttribute('data-o-video-data', JSON.stringify(quoteyData));
+				const video = new Video(containerEl);
+
+				return video
+					.getData()
+					.then(() => videoDataShouldMatch(video));
+			});
+		});
 	});
 });


### PR DESCRIPTION
Previously when the module was parsing JSON from data attributes, it was globally replacing all `'` to `"`.

As JSON is actually invalid when keys/values are wrapped in single quotes, then the transform seems irrelevant. This code was throwing when video data contained apostrophes.

The onus should be on the data provider to use valid JSON.