### PR TITLE
Defend against missing poster images & fix `data-o-video-placeholder-info` parsing

### DIFF
--- a/demos/src/captions.mustache
+++ b/demos/src/captions.mustache
@@ -1,7 +1,7 @@
 <div class="demo-video-container demo-video-container--large">
   <div class="o-video o-video--large"
     data-o-component="o-video"
-    data-o-video-id="eebe9cb5-8d4c-3bd7-8dd9-50e869e2f526"
+    data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
     data-o-video-advertising="false">
   </div>
 </div>

--- a/demos/src/placeholder.mustache
+++ b/demos/src/placeholder.mustache
@@ -1,7 +1,7 @@
 <div class="demo-video-container demo-video-container--large">
 	<div class="o-video o-video--large"
 		data-o-component="o-video"
-		data-o-video-id="4165329773001"
+		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-advertising="true"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-info="['title','description','brand']"></div>
@@ -9,8 +9,8 @@
 <label>
 	Select video:
 	<select class"demo-playlist">
-		<option value="5072828916001">Nationhood and the Edinburgh festivals</option>
-		<option value="4907997821001">Austrian far-right candidate narrowly defeated</option>
-		<option value="4165329773001">Teaching real-world economics to undergraduates</option>
+		<option value="773a4c8b-8b3f-4508-8ac5-1eae49a13476">Fox News scandal threatens Sky deal</option>
+		<option value="a20cfa9a-6d89-4eb0-97ea-18442259401b">S Korea’s new president set to rebalance region</option>
+		<option value="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2">FT's Editor on Macron and the UK elections</option>
 	</select>
 </label>

--- a/demos/src/playlist.mustache
+++ b/demos/src/playlist.mustache
@@ -8,7 +8,7 @@
 <br>
 
 <select size="3" disabled class="demo-playlist">
-	<option value="5072828916001">Nationhood and the Edinburgh festivals</option>
-	<option value="4907997821001">Austrian far-right candidate narrowly defeated</option>
-	<option value="4165329773001">Teaching real-world economics to undergraduates</option>
+	<option value="773a4c8b-8b3f-4508-8ac5-1eae49a13476">Fox News scandal threatens Sky deal</option>
+  <option value="a20cfa9a-6d89-4eb0-97ea-18442259401b">S Korea’s new president set to rebalance region</option>
+  <option value="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2">FT's Editor on Macron and the UK elections</option>
 </select>

--- a/demos/src/sizes.mustache
+++ b/demos/src/sizes.mustache
@@ -1,7 +1,7 @@
 <div class="demo-video-container demo-video-container--large">
 	<div class="o-video o-video--large"
 		data-o-component="o-video"
-		data-o-video-id="4165329773001"
+		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-info="['title','description','brand']"></div>
 </div>
@@ -9,7 +9,7 @@
 <div class="demo-video-container demo-video-container--medium">
 	<div class="o-video o-video--medium"
 		data-o-component="o-video"
-		data-o-video-id="4165329773001"
+		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-info="['title','description','brand']"></div>
 </div>
@@ -17,7 +17,7 @@
 <div class="demo-video-container demo-video-container--small">
 	<div class="o-video o-video--small"
 		data-o-component="o-video"
-		data-o-video-id="4165329773001"
+		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-info="['title','description','brand']"></div>
 </div>

--- a/demos/src/video.mustache
+++ b/demos/src/video.mustache
@@ -1,15 +1,15 @@
 <div class="demo-video-container demo-video-container--large">
 	<div class="o-video o-video--large"
 		data-o-component="o-video"
-		data-o-video-id="4165329773001"
+		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-advertising="true">
 	</div>
 </div>
 <label>
 	Select video:
 	<select class"demo-playlist">
-		<option value="5072828916001">Nationhood and the Edinburgh festivals</option>
-		<option value="4907997821001">Austrian far-right candidate narrowly defeated</option>
-		<option value="4165329773001">Teaching real-world economics to undergraduates</option>
+		<option value="773a4c8b-8b3f-4508-8ac5-1eae49a13476">Fox News scandal threatens Sky deal</option>
+		<option value="a20cfa9a-6d89-4eb0-97ea-18442259401b">S Korea’s new president set to rebalance region</option>
+		<option value="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2">FT's Editor on Macron and the UK elections</option>
 	</select>
 </label>

--- a/src/js/info.js
+++ b/src/js/info.js
@@ -34,8 +34,9 @@ class VideoInfo {
 	}
 
 	update () {
-		if (this.brandEl && this.video.videoData.brand && this.video.videoData.brand.name) {
-			this.brandEl.textContent = this.video.videoData.brand.name;
+		if (this.brandEl) {
+			const brandName = this.video.videoData.brand && this.video.videoData.brand.name;
+			this.brandEl.textContent = brandName;
 		}
 
 		if (this.titleEl) {

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -84,7 +84,15 @@ function getOptionsFromDataAttributes(attributes) {
 
 			try {
 				// If it's a JSON, a boolean or a number, we want it stored like that, and not as a string
-				opts[key] = JSON.parse(attr.value);
+
+				// For legacy o-video embeds, we'll need to check for placeHolderInfo attributes
+				// as they typically pass data in with single quotes, which won't parse:
+				// data-o-video-placeholder-info="['title', 'description']"
+				if (key === 'placeholderInfo') {
+					opts[key] = JSON.parse(attr.value.replace(/\'/g, '"'));
+				} else {
+					opts[key] = JSON.parse(attr.value);
+				}
 			} catch (e) {
 				opts[key] = attr.value;
 			}

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -185,7 +185,7 @@ class Video {
 
 		return dataPromise.then(data => {
 			this.videoData = data;
-			this.posterImage = updatePosterUrl(data.mainImageUrl, this.opts.optimumwidth);
+			this.posterImage = data.mainImageUrl && updatePosterUrl(data.mainImageUrl, this.opts.optimumwidth);
 			this.rendition = getRendition(data.renditions, this.opts);
 		});
 	}
@@ -276,7 +276,12 @@ class Video {
 	}
 
 	updateVideo() {
-		this.videoEl.poster = this.posterImage;
+		if (this.posterImage) {
+			this.videoEl.poster = this.posterImage;
+		} else {
+			this.videoEl.removeAttribute('poster');
+		}
+
 		this.videoEl.src = this.rendition && this.rendition.url;
 
 		if (this.opts.showCaptions === true) {
@@ -340,7 +345,10 @@ class Video {
 	}
 
 	updatePlaceholder() {
-		this.placeholderImageEl.src = this.posterImage;
+		if (this.posterImage) {
+			this.placeholderImageEl.src = this.posterImage;
+		}
+
 		this.infoPanel && this.infoPanel.update();
 	}
 

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -557,6 +557,24 @@ describe('Video', () => {
 				});
 			});
 
+			it('removes the poster if not supplied in data', () => {
+				const mediaApiNoPoster = Object.assign({}, mediaApiResponse2, { mainImageUrl: null });
+				const resNoPoster = new window.Response(JSON.stringify(mediaApiNoPoster), {
+					status: 200,
+					headers: { 'Content-type': 'application/json' }
+				});
+
+				fetchStub.resetBehavior();
+				fetchStub.returns(Promise.resolve(resNoPoster));
+
+				video.videoEl.poster.should.include('5393611350001');
+
+				const newOpts = { id: mediaApiResponse2.id };
+				return video.update(newOpts).then(() => {
+					video.videoEl.poster.should.equal('');
+				});
+			});
+
 			it('replaces the previous captions with the new ones', () => {
 				const resWithCaptions = new window.Response(JSON.stringify(mediaApiResponse2), {
 					status: 200,

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -54,12 +54,14 @@ describe('Video', () => {
 		it('should allow setting options through attribute', () => {
 			containerEl.setAttribute('data-o-video-optimumwidth', 300);
 			containerEl.setAttribute('data-o-video-placeholder', true);
+			containerEl.setAttribute('data-o-video-placeholder-info', '[\'title\', \'description\']');
 			containerEl.setAttribute('data-o-video-classes', 'a-class another-class');
 			containerEl.setAttribute('data-o-video-show-captions', true);
 
 			const video = new Video(containerEl);
 			video.opts.optimumwidth.should.eql(300);
 			video.opts.placeholder.should.eql(true);
+			video.opts.placeholderInfo.should.eql(['title', 'description']);
 			video.opts.classes.should.contain('a-class');
 			video.opts.classes.should.contain('another-class');
 			video.opts.showCaptions.should.eql(true);

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -504,7 +504,7 @@ describe('Video', () => {
 					id: 'eebe9cb5-8d4c-3bd7-8dd9-50e869e2f526',
 					autorender: false,
 					placeholder: true,
-					placeholderInfo: ['title']
+					placeholderInfo: ['title', 'brand']
 				});
 
 				return video.init();
@@ -528,6 +528,25 @@ describe('Video', () => {
 				return video.update(newOpts).then(() => {
 					video.placeholderImageEl.src.should.include('5394885102001');
 					video.infoPanel.titleEl.textContent.should.equal(mediaApiResponse2.title);
+				});
+			});
+
+			it('removes previous brand tag', () => {
+				const mediaApiNoBrand = Object.assign({}, mediaApiResponse2, { brand: null });
+				const resNoBrand = new window.Response(JSON.stringify(mediaApiNoBrand), {
+					status: 200,
+					headers: { 'Content-type': 'application/json' }
+				});
+
+				fetchStub.resetBehavior();
+				fetchStub.returns(Promise.resolve(resNoBrand));
+
+				const newOpts = { id: mediaApiResponse2.id };
+
+				video.infoPanel.brandEl.textContent.should.equal('Market Minute');
+
+				return video.update(newOpts).then(() => {
+					video.infoPanel.brandEl.textContent.should.equal('');
 				});
 			});
 		});


### PR DESCRIPTION
So this uncovered the possible origin behind the need for #101, and unfortunately we'll need to continue supporting that type of input.

Also updates demos to use a more up-to-date uuid.