### PR TITLE
Tone down hover state on video player, add focus state

### DIFF
--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -10,7 +10,7 @@
 	}
 
 	.o-video__placeholder {
-		background: oColorsGetPaletteColor('claret');
+		background: oColorsGetPaletteColor('slate');
 		color: oColorsGetPaletteColor('white');
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
@@ -55,6 +55,11 @@
 		left: 0;
 		margin: auto;
 		background-color: oColorsGetPaletteColor('black');
+
+		:hover > &,
+		:focus > & {
+			background-color: oColorsGetPaletteColor('claret');
+		}
 	}
 
 }


### PR DESCRIPTION
* Makes the overall feeling of the hover state less 'claret'
* Gives keyboard users a focus state on the focusable element, the play button itself

**Before:**
![before](https://cloud.githubusercontent.com/assets/295469/26061489/fe7923ae-397f-11e7-8843-8a73643ce705.gif)

**After:**
![new-hover](https://cloud.githubusercontent.com/assets/295469/26061493/00edca68-3980-11e7-85d8-01e20b2f98f6.gif)