### PR TITLE
Reload captions once advertising layer has finished

### DIFF
--- a/demos/src/captions.mustache
+++ b/demos/src/captions.mustache
@@ -1,7 +1,7 @@
 <div class="demo-video-container demo-video-container--large">
   <div class="o-video o-video--large"
     data-o-component="o-video"
-    data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
-    data-o-video-advertising="false">
+    data-o-video-id="f834a6d2-c84c-4c17-90fd-2b8593b1f8ba"
+    data-o-video-advertising="true">
   </div>
 </div>

--- a/src/js/ads.js
+++ b/src/js/ads.js
@@ -181,7 +181,7 @@ class VideoAds {
 		// If ads have failed to load, which resets the advertising support flag, play the video
 		// instead; otherwise, wait until the ads have loaded.
 		if (!this.video.opts.advertising) {
-			this.video.videoEl.play();
+			this.playUserVideo();
 		} else if (!this.adsLoaded) {
 			return;
 		}
@@ -199,7 +199,7 @@ class VideoAds {
 		} catch (adError) {
 			// An error may be thrown if there was a problem with the VAST response.
 			this.reportError(adError);
-			this.video.videoEl.play();
+			this.playUserVideo();
 		}
 	}
 
@@ -267,7 +267,7 @@ class VideoAds {
 				if (!ad.isLinear()) {
 					// Position AdDisplayContainer correctly for overlay.
 					// Use ad.width and ad.height.
-					this.video.videoEl.play();
+					this.playUserVideo();
 				}
 				break;
 			case google.ima.AdEvent.Type.STARTED:
@@ -343,6 +343,14 @@ class VideoAds {
 	contentResumeRequestHandler() {
 		this.video.containerEl.removeChild(this.adContainerEl);
 		this.adsCompleted = true;
+		this.playUserVideo();
+	}
+
+	playUserVideo() {
+		// Since Firefox 52, the captions need re-adding after the
+		// ad video layer has finished its thing.
+		this.video.addCaptions();
+
 		this.video.videoEl.play();
 	}
 

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -253,6 +253,10 @@ class Video {
 	}
 
 	addCaptions() {
+		if (this.opts.showCaptions === false) {
+			return;
+		}
+
 		if (typeof this.videoData === 'undefined') {
 			throw new Error('Please call `getData()` before calling `addCaptions()` directly.');
 		}
@@ -284,9 +288,7 @@ class Video {
 
 		this.videoEl.src = this.rendition && this.rendition.url;
 
-		if (this.opts.showCaptions === true) {
-			this.addCaptions();
-		}
+		this.addCaptions();
 	}
 
 	addPlaceholder() {

--- a/test/ads.test.js
+++ b/test/ads.test.js
@@ -16,7 +16,8 @@ describe('Ads', () => {
 			containerEl,
 			videoEl,
 			opts: {},
-			targeting: {}
+			targeting: {},
+			addCaptions: function() {}
 		};
 		ads = new Ads(video);
 	});


### PR DESCRIPTION
Fixes an issue seen on all videos with advertising on Firefox 52+ (including latest beta channel).

Even though the `<track>` element still exists in the DOM, the video player doesn't recognise it after the ad library has loaded.

Its likely to do with setting the `<video>`'s src *after* adding the `<track>` element (which I have a separate test environment for if interested) – but the ad library is complex and quite tricky to diagnose precisely.

This change introduces no visible decrease in performance.

Example video that has the issue: https://www.ft.com/video/f834a6d2-c84c-4c17-90fd-2b8593b1f8ba