### PR TITLE
Move play icon to pseudo element for IE background positioning

### DIFF
--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -49,12 +49,12 @@
 
 	.o-video__play-button-icon {
 		@include oIconsBaseStyles;
-		@include oIconsGetIcon('play', oColorsGetPaletteColor('white'), $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
 		position: absolute;
 		color: oColorsGetPaletteColor('white');
 		background-color: oColorsGetPaletteColor('black');
 
 		&:empty {
+			@include oIconsGetIcon('play', oColorsGetPaletteColor('white'), $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
 			bottom: 0;
 			left: 0;
 			width: 40px;
@@ -67,6 +67,18 @@
 			left: 10px;
 			padding: 10px 16px 10px 36px;
 			background-position: left;
+
+			&:before {
+				@include oIconsGetIcon('play', oColorsGetPaletteColor('white'), $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
+				display: block;
+				position: absolute;
+				content: '';
+				left: 5px;
+				width: 32px;
+				height: 32px;
+				margin-top: -16px;
+				top: 50%;
+			}
 		}
 
 		:hover > &,


### PR DESCRIPTION
Before, the play icon was centered within the button due to what IE sees as a toxic mix of `contain` and background-size.

![screen shot 2017-07-05 at 16 29 08](https://user-images.githubusercontent.com/295469/27906816-fee082fc-623c-11e7-9c64-7e6022dc909d.png)
