### PR TITLE
Use `will-change` to stop visual glitch on hover

### DIFF
--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -17,6 +17,7 @@
 	}
 
 	.o-video__placeholder-image {
+		will-change: opacity;
 		transition: opacity 0.25s;
 
 		// saves messing with z-indexes!


### PR DESCRIPTION
Sometimes heights don't round to whole numbers, creating a visual 'jump' when the opacity fades in/out on Chrome.

This isn't always evident because height of the video is `width + 56.25%`, so it depends on the width of the player.


![](http://g.recordit.co/RMQo8pfJXJ.gif)
