### PR TITLE
delete playButtonTextEl(DAC issue)

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -312,13 +312,9 @@ class Video {
 		const playButtonEl = document.createElement('button');
 		playButtonEl.className = 'o-video__play-button';
 
-		const playButtonTextEl = document.createElement('span');
-		playButtonTextEl.className = 'o-video__play-button-text';
-		playButtonTextEl.textContent = 'Play video';
-		playButtonEl.appendChild(playButtonTextEl);
-
 		const playButtonIconEl = document.createElement('span');
 		playButtonIconEl.className = 'o-video__play-button-icon';
+		playButtonIconEl.setAttribute('aria-label', 'Play video');
 		playButtonIconEl.textContent = this.opts.placeholderHint;
 		playButtonEl.appendChild(playButtonIconEl);
 

--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -40,16 +40,6 @@
 		cursor: pointer;
 	}
 
-	.o-video__play-button-text {
-		position: absolute;
-		clip: rect(0 0 0 0);
-		width: 1px;
-		height: 1px;
-		margin: -1px;
-		overflow: hidden;
-		color: oColorsGetPaletteColor('white');
-	}
-
 	.o-video__play-button-icon {
 		@include oIconsBaseStyles;
 		@include oIconsGetIcon('play', oColorsGetPaletteColor('white'), $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -456,11 +456,9 @@ describe('Video', () => {
 			video.addPlaceholder();
 
 			const playButtonEl = video.placeholderEl.querySelector('.o-video__play-button');
-			const playButtonTextEl = playButtonEl.querySelector('.o-video__play-button-text');
 			const playIconEl = playButtonEl.querySelector('.o-video__play-button-icon');
 
 			proclaim.ok(playButtonEl);
-			proclaim.ok(playButtonTextEl);
 			proclaim.ok(playIconEl);
 			proclaim.deepEqual(addEventListenerSpy.called, true);
 			proclaim.deepEqual(addEventListenerSpy.calledWith('click'), true);


### PR DESCRIPTION
**Issue ID: DAC_TECH_Buttons_Issue_01**(Video)
The play button for the video reads back to users as ‘Play button play button’. This may confuse some blind users.
Code Ref(s):
```
<button class="o-video__play-button"><span class="o-video__play-button-text">Play video</span><span class="o-video__play-button-icon">Play video</span></button>
```