### PR TITLE
Maintain placeholder image aspect ratio and center.

### DIFF
--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -8,6 +8,7 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
+		object-fit: cover;
 	}
 
 	.o-video__placeholder {

--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -8,7 +8,6 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
-		object-fit: cover;
 	}
 
 	.o-video__placeholder {
@@ -23,6 +22,7 @@
 	.o-video__placeholder-image {
 		will-change: opacity;
 		transition: opacity 0.25s;
+		object-fit: cover;
 
 		// saves messing with z-indexes!
 		:hover > & {


### PR DESCRIPTION
Before:
<img width="648" alt="Screenshot 2019-04-05 at 14 08 56" src="https://user-images.githubusercontent.com/10405691/55629947-657a0e00-57ac-11e9-8c68-e18db0d1a685.png">
After:
<img width="646" alt="Screenshot 2019-04-05 at 14 09 05" src="https://user-images.githubusercontent.com/10405691/55629949-657a0e00-57ac-11e9-90fb-43b86311e831.png">

Note: IE does not support this property.
