### PR TITLE
Require `systemcode` is configured.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,18 @@
 
 Version 6 updates its dependency on `o-icons`. It is no longer compatible with `o-icons@^4`. Ensure your project builds successfully without conflicts.
 
+A `systemcode` option is also required, which must be a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems) for the project using `o-video`. Set this declaratively using `data-o-video-systemcode` or by adding to the `opts` constructor argument.
+
+```diff
+import Video from 'o-video';
+const opts = {
+	id: 4165329773001,
+	optimumwidth: 710,
++	systemcode: 'my-biz-ops-code'
+};
+const video = new Video(document.body, opts);
+```
+
 ### Migrating from 4.0 to 5.0
 
 Version 5 introduces a new major of `o-loading`. Updating to this new version will mean updating any other components that you have which are using `o-loading`.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ const opts = {
 	id: 4165329773001,
 	optimumwidth: 710,
 	placeholder: true,
-	classes: ['video']
+	classes: ['video'],
+	systemcode: 'my-biz-ops-code'
 };
 const video = new Video(document.body, opts);
 ```
@@ -89,6 +90,7 @@ Where `opts` is an optional object with properties
  * `advertising` [`Boolean`] whether or not to show ads on the video
  * `showCaptions` [`Boolean`] whether or not to add captions to the video. Defaults to *true*.
  * `data` [`Object`] JSON object representing a [response from next-media-api](https://next-media-api.ft.com/v1/eebe9cb5-8d4c-3bd7-8dd9-50e869e2f526). If used, the component will not make a call to the API and use this data instead.
+ * `systemcode` [`String`] a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems) for the project using `o-video`.
 
 The config options can also be set as data attribute to instantiate the module declaratively:
 
@@ -112,7 +114,7 @@ const queue = [
 	'4165329773001'
 ];
 
-const player = new Video(document.body, { autorender: false });
+const player = new Video(document.body, { autorender: false, systemcode: 'my-biz-ops-code' });
 const playlist = new Video.Playlist({ player, queue });
 
 document.querySelector('.next-btn').onclick = () => playlist.next();

--- a/demos/src/captions.mustache
+++ b/demos/src/captions.mustache
@@ -1,6 +1,7 @@
 <div class="demo-video-container demo-video-container--large">
   <div class="o-video o-video--large"
     data-o-component="o-video"
+    data-o-video-systemcode="origami-build-tools"
     data-o-video-id="f834a6d2-c84c-4c17-90fd-2b8593b1f8ba"
     data-o-video-advertising="true">
   </div>

--- a/demos/src/placeholder-icon-hint.mustache
+++ b/demos/src/placeholder-icon-hint.mustache
@@ -2,6 +2,7 @@
 	<div class="o-video o-video--large"
 		data-o-component="o-video"
 		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
+		data-o-video-systemcode="origami-build-tools"
 		data-o-video-advertising="true"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-hint="Related video"

--- a/demos/src/placeholder.mustache
+++ b/demos/src/placeholder.mustache
@@ -3,6 +3,7 @@
 		data-o-component="o-video"
 		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-advertising="true"
+		data-o-video-systemcode="origami-build-tools"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-info="['title','description','brand']"></div>
 </div>

--- a/demos/src/playlist.mustache
+++ b/demos/src/playlist.mustache
@@ -1,5 +1,5 @@
 <div class="demo-video-container demo-video-container--large">
-	<div class="o-video o-video--large" data-o-component="o-video"></div>
+	<div class="o-video o-video--large" data-o-component="o-video" data-o-video-systemcode="origami-build-tools"></div>
 </div>
 
 <button name="prev" class="demo-button">Previous</button>

--- a/demos/src/sizes.mustache
+++ b/demos/src/sizes.mustache
@@ -1,6 +1,7 @@
 <div class="demo-video-container demo-video-container--large">
 	<div class="o-video o-video--large"
 		data-o-component="o-video"
+		data-o-video-systemcode="origami-build-tools"
 		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-info="['title','description','brand']"></div>
@@ -9,6 +10,7 @@
 <div class="demo-video-container demo-video-container--medium">
 	<div class="o-video o-video--medium"
 		data-o-component="o-video"
+		data-o-video-systemcode="origami-build-tools"
 		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-info="['title','description','brand']"></div>
@@ -17,6 +19,7 @@
 <div class="demo-video-container demo-video-container--small">
 	<div class="o-video o-video--small"
 		data-o-component="o-video"
+		data-o-video-systemcode="origami-build-tools"
 		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-placeholder="true"
 		data-o-video-placeholder-info="['title','description','brand']"></div>

--- a/demos/src/video.mustache
+++ b/demos/src/video.mustache
@@ -1,6 +1,7 @@
 <div class="demo-video-container demo-video-container--large">
 	<div class="o-video o-video--large"
 		data-o-component="o-video"
+		data-o-video-systemcode="origami-build-tools"
 		data-o-video-id="21d77b6c-1901-4d1d-9c3b-84dfe9904fd2"
 		data-o-video-advertising="true">
 	</div>

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -90,8 +90,8 @@ function addEvents(video, events) {
 }
 
 // use the image resizing service, if width supplied
-function updatePosterUrl(posterImage, width) {
-	let url = `https://www.ft.com/__origami/service/image/v2/images/raw/${encodeURIComponent(posterImage)}?source=o-video&quality=low`;
+function updatePosterUrl(posterImage, width, systemcode) {
+	let url = `https://www.ft.com/__origami/service/image/v2/images/raw/${encodeURIComponent(posterImage)}?source=${systemcode}&quality=low`;
 	if (width) {
 		url += `&fit=scale-down&width=${width}`;
 	}
@@ -172,6 +172,10 @@ class Video {
 
 		this.opts = Object.assign({}, defaultOpts, opts, getOptionsFromDataAttributes(this.containerEl.attributes));
 
+		if(typeof this.opts.systemcode !== 'string') {
+			throw new Error('o-video requires "systemcode" is configured using the "data-o-video-systemcode" data attribute, or configured with the `opts` constructor argument. It must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).');
+		}
+
 		if (typeof this.opts.classes === 'string') {
 			this.opts.classes = this.opts.classes.split(' ');
 		}
@@ -214,7 +218,7 @@ class Video {
 
 		return dataPromise.then(data => {
 			this.videoData = data;
-			this.posterImage = data.mainImageUrl && updatePosterUrl(data.mainImageUrl, this.opts.optimumwidth);
+			this.posterImage = data.mainImageUrl && updatePosterUrl(data.mainImageUrl, this.opts.optimumwidth, this.opts.systemcode);
 			this.rendition = getRendition(data.renditions, this.opts);
 		});
 	}

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -17,6 +17,7 @@ describe('Video', () => {
 		containerEl.setAttribute('data-o-video-id', 'eebe9cb5-8d4c-3bd7-8dd9-50e869e2f526');
 		containerEl.setAttribute('data-o-video-autorender', 'false');
 		containerEl.setAttribute('data-o-video-show-captions', 'false');
+		containerEl.setAttribute('data-o-video-systemcode', 'origami-build-tools');
 		document.body.appendChild(containerEl);
 	});
 
@@ -60,6 +61,7 @@ describe('Video', () => {
 			containerEl.setAttribute('data-o-video-placeholder-info', '[\'title\', \'description\']');
 			containerEl.setAttribute('data-o-video-classes', 'a-class another-class');
 			containerEl.setAttribute('data-o-video-show-captions', true);
+			containerEl.setAttribute('data-o-video-systemcode', 'test');
 
 			const video = new Video(containerEl);
 			proclaim.equal(video.opts.optimumwidth, 300);
@@ -68,6 +70,20 @@ describe('Video', () => {
 			proclaim.include(video.opts.classes, 'a-class');
 			proclaim.include(video.opts.classes, 'another-class');
 			proclaim.equal(video.opts.showCaptions, true);
+			proclaim.equal(video.opts.systemcode, 'test');
+		});
+
+		it('should error if a system code is not given', (done) => {
+			const testEl = containerEl.cloneNode(true);
+			testEl.removeAttribute('data-o-video-systemcode');
+
+			try {
+				new Video(testEl);
+			} catch (error) {
+				done();
+			}
+
+			throw new Error('o-video was created without a system code');
 		});
 	});
 
@@ -855,7 +871,7 @@ describe('Video', () => {
 					proclaim.deepEqual(video.posterImage,
 						'https://www.ft.com/__origami/service/image/v2/images/raw/' +
 						'https%3A%2F%2Fbcsecure01-a.akamaihd.net%2F13%2F47628783001%2F201704%2F970%2F47628783001_5393625566001_5393611350001-vs.jpg%3FpubId%3D47628783001%26videoId%3D5393611350001' +
-						'?source=o-video&quality=low&fit=scale-down&width=300'
+						'?source=origami-build-tools&quality=low&fit=scale-down&width=300'
 					);
 				});
 		});


### PR DESCRIPTION
So image service requests created by o-video JS may add the correct
source query parameter for attribution.

The demos are set to `origami-build-tools` so, for now, there won't be a
clear distinction between obt and the build service for all images.