### PR TITLE
replaces the showGuidance option property with a disableGuidance data…

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -158,7 +158,6 @@ const defaultOpts = {
 	placeholderHint: '',
 	playsinline: false,
 	showCaptions: true,
-	showGuidance: true,
 	data: null
 };
 
@@ -170,6 +169,7 @@ class Video {
 		this.fireWatchedEvent = unloadListener.bind(this);
 		this.visibilityListener = visibilityListener.bind(this);
 		this.didUserPressPlay = false;
+		this.disableGuidance = el.dataset.oVideoDisableguidance;
 
 		this.opts = Object.assign({}, defaultOpts, opts, getOptionsFromDataAttributes(this.containerEl.attributes));
 
@@ -202,7 +202,7 @@ class Video {
 			this.init();
 		}
 
-		if (this.opts.showGuidance) {
+		if (!this.disableGuidance) {
 			this.guidance = new Guidance();
 		}
 	}

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -968,13 +968,13 @@ describe('Video', () => {
 			});
 
 
-			it('is not displayed if showGuidance option is set false', () => {
-				containerEl.setAttribute('data-o-video-show-guidance', false);
+			it('is not displayed if disableGuidance option is set true', () => {
+				containerEl.setAttribute('data-o-video-disableGuidance', true);
 				const video = new Video(containerEl, { placeholder: true });
 
 				return video.init().then(() => {
 					proclaim.notOk(containerEl.querySelector('.o-video__guidance'));
-					containerEl.setAttribute('data-o-video-show-guidance', true);
+					containerEl.setAttribute('data-o-video-disableGuidance', false);
 				});
 			});
 		});
@@ -989,12 +989,12 @@ describe('Video', () => {
 			});
 
 			it('is not displayed for autoplaying videos if option is set to false', () => {
-				containerEl.setAttribute('data-o-video-show-guidance', false);
+				containerEl.setAttribute('data-o-video-disableGuidance', true);
 				const video = new Video(containerEl);
 				return video.init().then(() => {
 					video.videoEl.dispatchEvent(new Event('playing'));
 					proclaim.notOk(containerEl.querySelector('.o-video__guidance--banner'));
-					containerEl.setAttribute('data-o-video-show-guidance', true);
+					containerEl.setAttribute('data-o-video-disableGuidance', false);
 				});
 			});
 


### PR DESCRIPTION
…-attribute

Adds a data-attribute to disable the 'No captions available' guidance for videos. We want to remove this guidance for videos on the Front Page as tests have shown that it decreases engagement; [discussion in this trello ticket](https://trello.com/c/qSiuMpf4/110-remove-subtitles-info-from-video-promo-on-ft-homepage).  

This PR replaces the `showGuidance` video option with a `disableGuidance` data-attribute replacing the implementation in https://github.com/Financial-Times/o-video/pull/147 which was released as v5.2.0. This approach allows us to control the guidance in the same way in the video section and the top-stories section. 

Related PRS:
Related PR to implement this change in next-front-page: https://github.com/Financial-Times/next-front-page/pull/2208
Related PR in x-dash to pull in the new attribute: https://github.com/Financial-Times/x-dash/pull/421

