### PR TITLE
Gives the placeholder play button dimensions

### DIFF
--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -31,6 +31,7 @@
 	}
 
 	.o-video__play-button {
+		position: absolute;
 		bottom: 0;
 		padding: 0;
 		border: 0;
@@ -49,7 +50,6 @@
 	}
 
 	.o-video__play-cta {
-		position: absolute;
 		display: flex;
 		bottom: 0;
 		left: 0;


### PR DESCRIPTION
Previously the `<button>` element wouldn't have a position or dimensions
which resulted in no outline when it had focus.

This requires a focus outline so keyboard users are able to start the
video.

![Animation of video placeholder receiving focus](https://user-images.githubusercontent.com/524573/73370136-a303d680-42ab-11ea-870c-a96996710c23.gif)
