### PR TITLE
Always position the play button to the left.

### DIFF
--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -33,6 +33,8 @@
 	.o-video__play-button {
 		position: absolute;
 		bottom: 0;
+		// always align left, even when `text-align:center` is inherited
+		left: 0;
 		padding: 0;
 		border: 0;
 		background-color: transparent;


### PR DESCRIPTION
Always align left, even when `text-align:center` is inherited.
Fixes https://github.com/Financial-Times/o-video/issues/154

Before:
![Screen Shot 2020-02-19 at 17 01 16](https://user-images.githubusercontent.com/10405691/74856226-b0a3fd80-5339-11ea-8585-156ea7879e49.png)

After:
![Screen Shot 2020-02-19 at 17 01 03](https://user-images.githubusercontent.com/10405691/74856241-b994cf00-5339-11ea-861b-e1f0bb3a1837.png)
