### PR TITLE
Remove h4 heading from the optional o-video title

### DIFF
--- a/src/js/info.js
+++ b/src/js/info.js
@@ -17,7 +17,7 @@ class VideoInfo {
 		}
 
 		if (this.opts.title) {
-			this.titleEl = document.createElement('h4');
+			this.titleEl = document.createElement('span');
 			this.titleEl.className = 'o-video__info-title';
 			this.infoEl.appendChild(this.titleEl);
 		}

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -172,6 +172,8 @@ class Video {
 
 		this.opts = Object.assign({}, defaultOpts, opts, getOptionsFromDataAttributes(this.containerEl.attributes));
 
+		this.containerEl.setAttribute('aria-label', 'Video Player');
+
 		if(typeof this.opts.systemcode !== 'string') {
 			throw new Error('o-video requires "systemcode" is configured using the "data-o-video-systemcode" data attribute, or configured with the `opts` constructor argument. It must be set to a valid [Bizops system code](https://biz-ops.in.ft.com/list/Systems).');
 		}


### PR DESCRIPTION
1. We cannot assume an `h4` is the correct heading level in context.
2. The video title likely doesn't make sense as a heading in the
document context.
3. The heading is removed when the video is played. Just because a
video is played, the structure of the document shouldn't change.

Given point 2 and 3, we can set the element to a `span`. However as
a `span` the title of the video is read out as text by a screen
reader in the middle of a page without context. The title is then
repeated as part of the play button. To address that set
`aria-label="Video Player”` to the root `o-video` element which is
read `“Video Player, group“` by VoiceOver; giving useful context
when stepping through page content.

https://github.com/Financial-Times/o-video/issues/170