### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import OVideo from '../../src/js/video';
+import OVideo from '../../src/js/video.js';
 
 document.addEventListener("DOMContentLoaded", function() {
 	const video = new OVideo(document.querySelector('[data-o-component="o-video"]'));

--- a/demos/src/playlist.js
+++ b/demos/src/playlist.js
@@ -1,4 +1,4 @@
-import Video from '../../src/js/video';
+import Video from '../../src/js/video.js';
 
 document.addEventListener("DOMContentLoaded", function() {
 	const select = document.querySelector('select');

--- a/demos/src/sizes.js
+++ b/demos/src/sizes.js
@@ -1,4 +1,4 @@
-import OVideo from '../../src/js/video';
+import OVideo from '../../src/js/video.js';
 
 document.addEventListener("DOMContentLoaded", function() {
 	OVideo.init();

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Video from './src/js/video.js';
+import Video from './src/js/video.js.js';
 
 const constructAll = () => {
 	Video.init();

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Video from './src/js/video.js.js';
+import Video from './src/js/video.js';
 
 const constructAll = () => {
 	Video.init();

--- a/src/js/helpers/get-rendition.js
+++ b/src/js/helpers/get-rendition.js
@@ -1,4 +1,4 @@
-import supportedFormats from './supported-formats';
+import supportedFormats from './supported-formats.js';
 
 function getRendition(renditions, options) {
 	// allow mocking of supported formats module

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -1,10 +1,10 @@
 import oViewport from 'o-viewport';
 
-import getRendition from './helpers/get-rendition';
-import VideoAds from './ads';
-import VideoInfo from './info';
-import Playlist from './playlist';
-import Guidance from './guidance';
+import getRendition from './helpers/get-rendition.js';
+import VideoAds from './ads.js';
+import VideoInfo from './info.js';
+import Playlist from './playlist.js';
+import Guidance from './guidance.js';
 
 function listenOnce(el, eventName, fn) {
 	const wrappedFn = function(...args) {

--- a/test/ads.test.js
+++ b/test/ads.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon google */
 
-import Ads from './../src/js/ads';
+import Ads from './../src/js/ads.js';
 
 describe('Ads', () => {
 

--- a/test/helpers/get-rendition.test.js
+++ b/test/helpers/get-rendition.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import getRendition from './../../src/js/helpers/get-rendition';
-import { mediaApiResponse1 } from '../fixtures/media-api-1.js';
+import getRendition from './../../src/js/helpers/get-rendition.js';
+import { mediaApiResponse1 } from '../fixtures/media-api-1.js.js';
 
 const renditions = mediaApiResponse1.renditions;
 

--- a/test/helpers/get-rendition.test.js
+++ b/test/helpers/get-rendition.test.js
@@ -2,7 +2,7 @@
 /* global proclaim */
 
 import getRendition from './../../src/js/helpers/get-rendition.js';
-import { mediaApiResponse1 } from '../fixtures/media-api-1.js.js';
+import { mediaApiResponse1 } from '../fixtures/media-api-1.js';
 
 const renditions = mediaApiResponse1.renditions;
 

--- a/test/helpers/supported-formats.test.js
+++ b/test/helpers/supported-formats.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import supportedFormats from './../../src/js/helpers/supported-formats';
+import supportedFormats from './../../src/js/helpers/supported-formats.js';
 
 describe('Supported Formats', () => {
 

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import Player from '../src/js/video';
-import Subject from '../src/js/playlist';
+import Player from '../src/js/video.js';
+import Subject from '../src/js/playlist.js';
 
 function createPlayer () {
 	const stub = sinon.createStubInstance(Player);

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -2,7 +2,7 @@
 /* global proclaim sinon */
 
 import Video from './../src/js/video.js';
-import {mediaApiResponse1} from './fixtures/media-api-1.js.js';
+import {mediaApiResponse1} from './fixtures/media-api-1.js';
 import {mediaApiResponse2} from './fixtures/media-api-2.js.js';
 
 describe('Video', () => {

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -3,7 +3,7 @@
 
 import Video from './../src/js/video.js';
 import {mediaApiResponse1} from './fixtures/media-api-1.js';
-import {mediaApiResponse2} from './fixtures/media-api-2.js.js';
+import {mediaApiResponse2} from './fixtures/media-api-2.js';
 
 describe('Video', () => {
 

--- a/test/video.test.js
+++ b/test/video.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import Video from './../src/js/video';
-import {mediaApiResponse1} from './fixtures/media-api-1.js';
-import {mediaApiResponse2} from './fixtures/media-api-2.js';
+import Video from './../src/js/video.js';
+import {mediaApiResponse1} from './fixtures/media-api-1.js.js';
+import {mediaApiResponse2} from './fixtures/media-api-2.js.js';
 
 describe('Video', () => {
 


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing