### PR TITLE
Don't nest caption link within play button - CI-788

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -356,6 +356,9 @@ class Video {
 		const playCTA = document.createElement('div');
 		playCTA.className = `o-video__play-cta ${this.opts.placeholderHint ? 'o-video__play-cta--with-hint' : 'o-video__play-cta--without-hint'}`;
 
+		this.placeholderControls = document.createElement('div');
+		this.placeholderControls.className = 'o-video__placeholder-controls';
+
 		this.playButtonEl = document.createElement('button');
 		this.playButtonEl.className = 'o-video__play-button';
 
@@ -363,16 +366,17 @@ class Video {
 		playButtonIconEl.className = 'o-video__play-button-icon';
 		playButtonIconEl.textContent = this.opts.placeholderHint;
 
-
 		playCTA.appendChild(playButtonIconEl);
+
+		this.playButtonEl.appendChild(playCTA);
+		this.placeholderControls.appendChild(this.playButtonEl);
 
 		const { captionsUrl } = this.videoData || {};
 		if (!captionsUrl && this.guidance) {
-			playCTA.appendChild(this.guidance.createPlaceholder());
+			this.placeholderControls.appendChild(this.guidance.createPlaceholder());
 		}
-		this.playButtonEl.appendChild(playCTA);
 
-		this.placeholderEl.appendChild(this.playButtonEl);
+		this.placeholderEl.appendChild(this.placeholderControls);
 
 		this.placeholderEl.addEventListener('click', () => {
 			this.didUserPressPlay = true;

--- a/src/scss/_placeholder.scss
+++ b/src/scss/_placeholder.scss
@@ -30,11 +30,15 @@
 		}
 	}
 
-	.o-video__play-button {
+	.o-video__placeholder-controls {
+		display: flex;
 		position: absolute;
 		bottom: 0;
 		// always align left, even when `text-align:center` is inherited
 		left: 0;
+	}
+
+	.o-video__play-button {
 		padding: 0;
 		border: 0;
 		background-color: transparent;


### PR DESCRIPTION
### Problem

Previously the guidance element which contains a link was nested within the play button.

Interactive elements shouldn't be nested within each other.


### Screenshots

**Before fix**
<img width="642" alt="Screenshot of the video component before the fix" src="https://user-images.githubusercontent.com/524573/132028486-ed615b8d-0578-4eb4-9470-47b9786fbafb.png">


**After fix**

<img width="640" alt="Screenshot of the video component after the fix" src="https://user-images.githubusercontent.com/524573/132028498-374fe7cf-301c-4060-a298-702e164d845c.png">
